### PR TITLE
Send race fix

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -390,7 +390,12 @@ func (l *Conn) sendMessageWithFlags(packet *ber.Packet, flags sendMessageFlags) 
 			responses: responses,
 		},
 	}
-	l.sendProcessMessage(message)
+	if !l.sendProcessMessage(message) {
+		if l.IsClosing() {
+			return nil, NewError(ErrorNetwork, errors.New("ldap: connection closed"))
+		}
+		return nil, NewError(ErrorNetwork, errors.New("ldap: could not send message for unknown reason"))
+	}
 	return message.Context, nil
 }
 


### PR DESCRIPTION
Fix the handling of a race where the connection is closed between the isClosing test at the top of sendMessageWithFlags, and a subsequently ignored test in sendProcessMessage.